### PR TITLE
Implement `+` and `-` operation with AbstractArray

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -20,6 +20,12 @@ end
 @inline Base.:+(x::AbstractTensor) = x
 @inline Base.:-(x::AbstractTensor) = _map(-, x)
 
+# with AbstractArray
+@generated Base.:+(x::AbstractTensor, y::AbstractArray) = :(@_inline_meta; x + convert($(tensortype(Space(size(x)))), y))
+@generated Base.:+(x::AbstractArray, y::AbstractTensor) = :(@_inline_meta; convert($(tensortype(Space(size(y)))), x) + y)
+@generated Base.:-(x::AbstractTensor, y::AbstractArray) = :(@_inline_meta; x - convert($(tensortype(Space(size(x)))), y))
+@generated Base.:-(x::AbstractArray, y::AbstractTensor) = :(@_inline_meta; convert($(tensortype(Space(size(y)))), x) - y)
+
 @generated function _add_uniform(x::AbstractSquareTensor{dim}, λ::Real) where {dim}
     S = promote_space(Space(x), Space(Symmetry(dim, dim)))
     tocartesian = CartesianIndices(S)

--- a/test/Tensor.jl
+++ b/test/Tensor.jl
@@ -200,8 +200,8 @@ end
             vdata = map(T, (1:3...,))
             @test (@inferred convert(Vec{3, T}, v))::Vec{3, T} |> Tuple == vdata
             # convert symmetric tensor to tensor
-            (@inferred convert(Tensor{Tuple{3, 3}, T}, S))::Tensor{Tuple{3, 3}, T} |> Array == Array(S)
-            (@inferred convert(Mat{3, 3, T}, S))::Tensor{Tuple{3, 3}, T} |> Array == Array(S)
+            (@inferred convert(Tensor{Tuple{3, 3}, T}, S))::Tensor{Tuple{3, 3}, T} == Array(S)
+            (@inferred convert(Mat{3, 3, T}, S))::Tensor{Tuple{3, 3}, T} == Array(S)
             # convert tensor to symmetric tensor
             @test_throws Exception convert(Tensor{Tuple{@Symmetry{3, 3}}, T}, A)
         end

--- a/test/inv.jl
+++ b/test/inv.jl
@@ -35,8 +35,8 @@ end
         A = rand(SecondOrderTensor{dim, T})
         S = rand(SymmetricSecondOrderTensor{dim, T})
         b = rand(Vec{dim, T})
-        @test (@inferred A \ b)::Vec{dim, T} |> Array ≈ Array(A) \ Array(b)
-        @test (@inferred S \ b)::Vec{dim, T} |> Array ≈ Array(S) \ Array(b)
+        @test (@inferred A \ b)::Vec{dim, T} ≈ Array(A) \ Array(b)
+        @test (@inferred S \ b)::Vec{dim, T} ≈ Array(S) \ Array(b)
     end
     @testset "Fast version using block matrix algorithm" begin
         for T in (Float32, Float64), dim in 1:11
@@ -45,8 +45,8 @@ end
             S = rand(SymmetricSecondOrderTensor{dim, T})
             b = rand(Vec{dim, T})
             if T == Float64
-                @test (@inferred Tensorial.fastsolve(A, b))::Vec{dim, T} |> Array ≈ Array(A) \ Array(b)
-                @test (@inferred Tensorial.fastsolve(S, b))::Vec{dim, T} |> Array ≈ Array(S) \ Array(b)
+                @test (@inferred Tensorial.fastsolve(A, b))::Vec{dim, T} ≈ Array(A) \ Array(b)
+                @test (@inferred Tensorial.fastsolve(S, b))::Vec{dim, T} ≈ Array(S) \ Array(b)
             else
                 @test_throws Exception Tensorial.fastsolve(A, b)
                 @test_throws Exception Tensorial.fastsolve(S, b)

--- a/test/ops.jl
+++ b/test/ops.jl
@@ -16,6 +16,11 @@
         @test (@inferred +y)::typeof(y) == y
         @test (@inferred -x)::typeof(x) == -Array(x)
         @test (@inferred -y)::typeof(y) == -Array(y)
+        # with Array
+        @test (@inferred x + Array(y))::Tensor{Tuple{size(x)...}, T} == Array(x) + Array(y)
+        @test (@inferred Array(x) + y)::Tensor{Tuple{size(y)...}, T} == Array(x) + Array(y)
+        @test (@inferred x - Array(y))::Tensor{Tuple{size(x)...}, T} == Array(x) - Array(y)
+        @test (@inferred Array(x) - y)::Tensor{Tuple{size(y)...}, T} == Array(x) - Array(y)
         # check eltype promotion
         x = Vec(1, 0)
         y = Vec(T(1), 0)

--- a/test/ops.jl
+++ b/test/ops.jl
@@ -44,7 +44,7 @@ end
             for i in axes(X,1), j in axes(X,2), k in axes(X,3), l in axes(Y,2), m in axes(Y,3)
                 Z[i,j,l,m] += X[i,j,k] * Y[k,l,m]
             end
-            @test Array(z) ≈ Z
+            @test z ≈ Z
             # double contraction
             z = (@inferred contraction(x, y, Val(2)))::Tensor{Tuple{3,3}, T}
             X = Array(x);
@@ -53,7 +53,7 @@ end
             for i in axes(X,1), j in axes(X,2), k in axes(X,3), l in axes(Y,3)
                 Z[i,l] += X[i,j,k] * Y[j,k,l]
             end
-            @test Array(z) ≈ Z
+            @test z ≈ Z
             # triple contraction
             z = (@inferred contraction(x, y, Val(3)))::T
             X = Array(x);
@@ -71,7 +71,7 @@ end
             for i in axes(X,1), j in axes(X,2), k in axes(X,3), l in axes(Y,1), m in axes(Y,2), n in axes(Y,3)
                 Z[i,j,k,l,m,n] = X[i,j,k] * Y[l,m,n]
             end
-            @test Array(z) ≈ Z
+            @test z ≈ Z
         end
     end
     @testset "otimes/dot/norm" begin
@@ -80,7 +80,7 @@ end
             x = rand(Vec{3, T})
             y = rand(Vec{3, T})
             z = (@inferred x ⊗ y)::Tensor{Tuple{3,3}, T}
-            @test Array(z) ≈ Array(x) * Array(y)'
+            @test z ≈ Array(x) * Array(y)'
             @test (@inferred x ⋅ y) ≈ Array(x)' * Array(y)
             @test (@inferred norm(x)) ≈ norm(Array(x))
             @test (@inferred norm(z)) ≈ norm(Array(z))
@@ -88,7 +88,7 @@ end
             x = rand(Vec{3, T})
             y = rand(Vec{2, T})
             z = (@inferred x ⊗ y)::Tensor{Tuple{3,2}, T}
-            @test Array(z) ≈ Array(x) * Array(y)'
+            @test z ≈ Array(x) * Array(y)'
             @test (@inferred norm(z)) ≈ norm(Array(z))
         end
     end
@@ -115,7 +115,7 @@ end
             x = rand(SecondOrderTensor{3, T})
             y = rand(SymmetricSecondOrderTensor{3, T})
             xᵀ = (@inferred transpose(x))::typeof(x)
-            @test Array(x') == Array(xᵀ) == Array(x)'
+            @test x' == xᵀ == Array(x)'
             @test (@inferred transpose(y))::typeof(y) == y' == y
         end
     end
@@ -190,9 +190,9 @@ end
             end
             # 2D rotmat
             @test (@inferred rotmat(α))::Mat{2,2,T} ≈ (@inferred rotmat(rad2deg(α), degree = true))
-            @test (@inferred rotmat(α)) |> Array ≈ (@inferred rotmatx(α))[[2,3], [2,3]]
-            @test (@inferred rotmat(α)) |> Array ≈ (@inferred rotmaty(α))[[3,1], [3,1]]
-            @test (@inferred rotmat(α)) |> Array ≈ (@inferred rotmatz(α))[[1,2], [1,2]]
+            @test (@inferred rotmat(α)) ≈ (@inferred rotmatx(α))[[2,3], [2,3]]
+            @test (@inferred rotmat(α)) ≈ (@inferred rotmaty(α))[[3,1], [3,1]]
+            @test (@inferred rotmat(α)) ≈ (@inferred rotmatz(α))[[1,2], [1,2]]
             # 3D rotmat
             @test (@inferred rotmatx(α))::Mat{3,3,T} ≈ (@inferred rotmatx(rad2deg(α), degree = true))::Mat{3,3,T}
             @test (@inferred rotmaty(α))::Mat{3,3,T} ≈ (@inferred rotmaty(rad2deg(α), degree = true))::Mat{3,3,T}
@@ -209,8 +209,8 @@ end
         for T in (Float32, Float64)
             for dim in (2, 3)
                 x = rand(SymmetricSecondOrderTensor{dim, T})
-                @test (@inferred eigvals(x)) |> Array ≈ eigvals(Array(x))
-                @test (@inferred eigen(x)).values |> Array ≈ eigen(Array(x)).values
+                @test (@inferred eigvals(x)) ≈ eigvals(Array(x))
+                @test (@inferred eigen(x)).values ≈ eigen(Array(x)).values
                 @test (@inferred eigen(x)).vectors ≈ (@inferred eigvecs(x))
             end
         end


### PR DESCRIPTION
This fixes an error by `isapprox(::Tensor, ::AbstractArray)`.