### PR TITLE
Disable SIMD computation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,10 @@ version = "0.9.3"
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ForwardDiff = "0.10"
-SIMD = "3"
 StaticArrays = "1"
 julia = "1.5"

--- a/src/Tensorial.jl
+++ b/src/Tensorial.jl
@@ -7,7 +7,6 @@ export ⋅, ×, dot, tr, det, norm, normalize, mean, I, cross, eigen, eigvals, e
 using StaticArrays
 using Base: @pure, @_inline_meta, @_propagate_inbounds_meta
 using ForwardDiff: Dual, value, partials
-import SIMD
 import StaticArrays: qr, lu, svd, diag, diagm # defined in LinearAlgebra, but call methods in StaticArrays
 # re-exports from StaticArrays
 export qr, lu, svd, diag, diagm
@@ -87,7 +86,7 @@ include("continuum_mechanics.jl")
 include("inv.jl")
 include("voigt.jl")
 include("ad.jl")
-include("simd.jl")
+# include("simd.jl")
 include("broadcast.jl")
 
 include("quaternion.jl")

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -168,9 +168,9 @@ end
 
 # for dummy indices
 @inline function sumargs(x, ys...)
-    ret = *(x...)
+    ret = prod(x)
     @simd for i in eachindex(ys)
-        @inbounds ret += *(ys[i]...)
+        @inbounds ret += prod(ys[i])
     end
     ret
 end


### PR DESCRIPTION
In most cases, using SIMD computation become slow now.

```julia
(Tensorial) pkg> st
     Project Tensorial v0.9.3
      Status `~/Documents/Source code/Julia/Tensorial/Project.toml`
  [f6369f11] ForwardDiff v0.10.19
  [fdea26ae] SIMD v3.3.1
  [90137ffa] StaticArrays v1.2.12
  [37e2e46d] LinearAlgebra
  [10745b16] Statistics
```