### PR TITLE
Remove sumargs, SIMD only for summation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tensorial"
 uuid = "98f94333-fa9f-48a9-ad80-1c66397b2b38"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
-version = "0.12.8"
+version = "0.12.9"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"


### PR DESCRIPTION
This solves unexpected slow AD calculations. For example, `norm` becomes 4 times faster. I don't know why...

Before:

```jl
julia> using Tensorial, BenchmarkTools

julia> x = rand(SymmetricSecondOrderTensor{3});

julia> @benchmark gradient(norm, $(Ref(x))[], :all)
BenchmarkTools.Trial: 10000 samples with 996 evaluations.
 Range (min … max):  27.108 ns … 61.998 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     28.196 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   28.419 ns ±  1.415 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▁▄    █▃  ▂▃                                               ▁
  ▂██▄▄▇▇██▆▆███▆▄▆▄▅▄▄▅▃▃▂▅▄▃▄▂█▄▅▅▄▅▅▄▄▅▅▅▅▅▅▄▄▅▃▃▂▃▂▃▄▄▅▃▄ █
  27.1 ns      Histogram: log(frequency) by time      35.6 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

After:

```jl
julia> using Tensorial, BenchmarkTools

julia> x = rand(SymmetricSecondOrderTensor{3});

julia> @benchmark gradient(norm, $(Ref(x))[], :all)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  7.041 ns … 33.791 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.333 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.301 ns ±  0.590 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

             ▁     █                      █     █
  ▂▁▁▁▁▂▁▁▁▁▁█▁▁▁▁▁█▁▁▁▁▁▃▁▁▁▁▁▂▁▁▁▁▃▁▁▁▁▁█▁▁▁▁▁█▁▁▁▁▁▃▁▁▁▁▂ ▃
  7.04 ns        Histogram: frequency by time        7.46 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```