### PR TITLE
Fix wrong unary operation in `@einsum`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tensorial"
 uuid = "98f94333-fa9f-48a9-ad80-1c66397b2b38"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -63,6 +63,12 @@ end
         check_value_and_type((@einsum (i,j) -> S3[j,k,i] * v1[k]), permutedims(S3, Val((3,1,2))) ⋅ v1, (@tensor t[i,j] := Array(S3)[j,k,i] * Array(v1)[k]))
         check_value_and_type((@einsum (j) -> v1[i] * S3[j,k,i] * v1[k]), (S3 ⋅ v1) ⋅ v1, (@tensor t[j] := Array(v1)[i] * Array(S3)[j,k,i] * Array(v1)[k]))
         check_value_and_type((@einsum v1[i] * S3[j,k,i] * v1[k]), (S3 ⋅ v1) ⋅ v1, (@tensor t[j] := Array(v1)[i] * Array(S3)[j,k,i] * Array(v1)[k]))
+
+        # unary operator (#201)
+        a = Vec(1,0,0)
+        b = Vec(0,1,0)
+        check_value_and_type((@einsum -a[μ]*a[v] + b[μ]*b[v]), -a ⊗ a + b ⊗ b, (@tensor t[μ,v] := -Array(a)[μ] * Array(a)[v] + Array(b)[μ] * Array(b)[v]))
+        check_value_and_type((@einsum b[μ]*b[v] + -a[μ]*a[v]), b ⊗ b + -a ⊗ a, (@tensor t[μ,v] := Array(b)[μ] * Array(b)[v] + -Array(a)[μ] * Array(a)[v]))
     end
     @testset "errors" begin
         S1 = rand(SymmetricSecondOrderTensor{3})


### PR DESCRIPTION
Fix #201.

@TakeTwiceDailey, thanks for your report. This is a critical bug. It should now be fixed as:

```jl
julia> a = @Vec [1,0,0];

julia> b = @Vec [0,1,0];

julia> @einsum -a[μ]*a[v] + b[μ]*b[v]
3×3 Tensor{Tuple{3, 3}, Int64, 2, 9}:
 -1  0  0
  0  1  0
  0  0  0

julia> @einsum b[μ]*b[v] + -a[μ]*a[v]
3×3 Tensor{Tuple{3, 3}, Int64, 2, 9}:
 -1  0  0
  0  1  0
  0  0  0
```