### PR TITLE
Fix unexpected InexactError in convert

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tensorial"
 uuid = "98f94333-fa9f-48a9-ad80-1c66397b2b38"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
-version = "0.18.5"
+version = "0.18.6"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -300,7 +300,7 @@ end
     quote
         @_inline_meta
         @inbounds y = $TT(tuple($(exps...)))
-        $(S != Sy) && x != y && throw(InexactError(:convert, TT, x))
+        $(S != Sy) && convert_eltype(eltype(TT), x) != y && throw(InexactError(:convert, TT, x))
         y
     end
 end

--- a/test/Tensor.jl
+++ b/test/Tensor.jl
@@ -250,6 +250,9 @@ end
             @test (@inferred convert(Tensor{Tuple{@Symmetry{3, 3}}, T}, A+A')) == Array(A+A')
             @test_throws InexactError convert(Tensor{Tuple{@Symmetry{3, 3}}, T}, A)
         end
+        # Float64 -> Float32
+        x = rand(Mat{3,3,Float64})
+        (@inferred convert(SymmetricSecondOrderTensor{3,Float32}, x+x'))::SymmetricSecondOrderTensor{3,Float32}
     end
     @testset "AbstractArray -> Tensor" begin
         A = [1 3; 2 4]


### PR DESCRIPTION
Fix the following error:

```Julia
julia> x = rand(Mat{3,3})
3×3 Tensor{Tuple{3, 3}, Float64, 2, 9}:
 0.312456  0.196658  0.0523662
 0.89889   0.502584  0.203069
 0.55225   0.554792  0.626731

julia> convert(SymmetricSecondOrderTensor{3,Float32}, x+x') # Float64 -> Float32
ERROR: InexactError: convert(SymmetricSecondOrderTensor{3, Float32}, [0.624912624332777 1.095547887141247 0.6046159926632485; 1.095547887141247 1.0051676485440664 0.7578614928630638; 0.6046159926632485 0.7578614928630638 1.2534626901973718])
Stacktrace:
 [1] macro expansion
   @ ~/Documents/Source code/Julia/Tensorial/src/Tensor.jl:303 [inlined]
 [2] convert(::Type{SymmetricSecondOrderTensor{3, Float32}}, x::Tensor{Tuple{3, 3}, Float64, 2, 9})
   @ Tensorial ~/Documents/Source code/Julia/Tensorial/src/Tensor.jl:296
 [3] top-level scope
   @ REPL[3]:1
```