### PR TITLE
Improve `@einsum` contraction strategy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tensorial"
 uuid = "98f94333-fa9f-48a9-ad80-1c66397b2b38"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
 
 [deps]

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -173,23 +173,17 @@ end
 
 # contraction
 function einsum_instantiate_contraction(TT, exprs::Vector{EinsumExpr})
-    freeinds = find_freeindices(mapreduce(x->x.freeinds, vcat, exprs))
-
-    if length(exprs) > 2
-        dummies_list = findall(exprs) do einex # tensors having only dummy indices
-            isscalarexpr(einex) || !any(in(freeinds), einex.freeinds)
-        end
-        # compute dummy indices first, improving performance (#191)
-        if !isempty(dummies_list)
-            dummies = exprs[dummies_list]
-            deleteat!(exprs, dummies_list)
-            exprs = [dummies; exprs]
-        end
+    isempty(exprs) && error("@einsum: empty contraction expression")
+    length(exprs) == 1 && return only(exprs)
+    exprs = copy(exprs)
+    while length(exprs) > 2
+        i, j = best_contraction_pair(exprs)
+        einex = einsum_instantiate_contraction(exprs[i], exprs[j], :Any)
+        deleteat!(exprs, j)
+        deleteat!(exprs, i)
+        insert!(exprs, i, einex)
     end
-
-    # lastly apply `TT`
-    ex = foldl(einsum_instantiate_contraction, exprs[1:end-1])
-    einsum_instantiate_contraction(ex, exprs[end], TT)
+    return einsum_instantiate_contraction(exprs[1], exprs[2], TT)
 end
 
 function einsum_instantiate_contraction(lhs::EinsumExpr, rhs::EinsumExpr, TT = :Any)
@@ -209,6 +203,41 @@ function einsum_instantiate_contraction(lhs::EinsumExpr, rhs::EinsumExpr, TT = :
         end
         return EinsumExpr(ex, free_indices, [lhs.allinds; rhs.allinds])
     end
+end
+
+function contraction_cost(lhs::EinsumExpr, rhs::EinsumExpr)
+    inds = [lhs.freeinds; rhs.freeinds]
+    freeinds = find_freeindices(inds)
+    dummies = setdiff(inds, freeinds)
+
+    N = length(dummies)
+
+    is_fast_contract = false
+
+    if N > 0
+        lhs_dims = map(i -> only(findall(==(i), lhs.freeinds)), dummies)
+        rhs_dims = map(i -> only(findall(==(i), rhs.freeinds)), dummies)
+
+        lhs_tail = collect((length(lhs.freeinds)-N+1):length(lhs.freeinds))
+        rhs_head = collect(1:N)
+
+        is_fast_contract = lhs_dims == lhs_tail && rhs_dims == rhs_head
+    end
+
+    return (!is_fast_contract, -N, length(freeinds))
+end
+
+function best_contraction_pair(exprs::Vector{EinsumExpr})
+    best = (1, 2)
+    cost = contraction_cost(exprs[1], exprs[2])
+    for i in 1:(length(exprs)-1), j in (i+1):length(exprs)
+        c = contraction_cost(exprs[i], exprs[j])
+        if c < cost
+            best = (i, j)
+            cost = c
+        end
+    end
+    return best
 end
 
 # this returns expressions for each index

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -1,3 +1,5 @@
+using Tensorial: EinsumExpr, best_contraction_pair
+
 function check_value_and_type(x, y, z)
     @test x ≈ y ≈ z
     @test typeof(x) == typeof(y)
@@ -82,5 +84,32 @@ end
         # @test_throws Exception (@einsum (k) -> S1[i,j] * S1[i,j])
         # @test_throws Exception (@einsum (j) -> S1[i,i] * S1[i,j])
         # @test_throws Exception (@einsum S1[i,i] * S1[i,j])
+    end
+    @testset "@einsum contraction strategy" begin
+        A = EinsumExpr(:A, [:i, :j], [:i, :j])
+        B = EinsumExpr(:B, [:k, :l], [:k, :l])
+        C = EinsumExpr(:C, [:j, :k], [:j, :k])
+        D = EinsumExpr(:D, [:l, :i], [:l, :i])
+
+        @test best_contraction_pair([A, B, C, D]) == (1, 3)
+        @test best_contraction_pair([A, C, B, D]) == (1, 2)
+
+        A = EinsumExpr(:A, [:i, :j], [:i, :j])
+        B = EinsumExpr(:B, [:j, :k], [:j, :k])
+        C = EinsumExpr(:C, [:k, :l], [:k, :l])
+
+        @test best_contraction_pair([A, B, C]) == (1, 2)
+
+        A = EinsumExpr(:A, [:i, :j], [:i, :j])
+        B = EinsumExpr(:B, [:k, :l], [:k, :l])
+        C = EinsumExpr(:C, [:j, :k], [:j, :k])
+
+        @test best_contraction_pair([A, B, C]) == (1, 3)
+
+        A = EinsumExpr(:A, [:j, :i], [:j, :i])
+        B = EinsumExpr(:B, [:k, :j], [:k, :j])
+        C = EinsumExpr(:C, [:l, :k], [:l, :k])
+
+        @test best_contraction_pair([A, B, C]) == (1, 2)
     end
 end


### PR DESCRIPTION
This PR improves the contraction strategy used by `@einsum`.

The new strategy prioritizes contraction pairs that can be lowered to the fast `contract(x, y, Val(N))` path, reducing sensitivity to the input order of multiplicative terms. This helps avoid inefficient contraction trees and unnecessary axis permutations in common tensor contraction patterns.

This may fix #242.

In the example below, two equivalent expressions previously generated different contraction trees and showed a large performance gap. With this PR, they generate the same contraction structure and have comparable performance.

Before PR:

```Julia
julia> using Tensorial

julia> using BenchmarkTools

julia> A = rand(Mat{3,3});

julia> B = rand(Mat{3,3});

julia> C = rand(Mat{3,3});

julia> D = rand(Mat{3,3});

julia> @benchmark @einsum $(Ref(A))[][i,j] * $(Ref(B))[][k,l] * $(Ref(C))[][j,k] * $(Ref(D))[][l,i]
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  13.041 ns … 138.959 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     13.375 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.465 ns ±   2.252 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▄ ▆ ▃ ▂   ▁  ▆ █ ▅ ▄ ▂ ▂ ▅  ▂                      ▁       ▂
  ▇▁█▁█▁█▁█▁█▁█▁▁█▁█▁█▁█▁█▁█▁█▁▁█▁█▁▇▁▇▁▆▁▅▁▆▁▄▆▁▆▁▅▁█▁█▁▇▁▆▁▅ █
  13 ns         Histogram: log(frequency) by time      14.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark @einsum $(Ref(A))[][i,j] * $(Ref(C))[][j,k] * $(Ref(B))[][k,l] * $(Ref(D))[][l,i]
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  5.750 ns … 23.208 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.875 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.963 ns ±  0.430 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▃  █  ▆  ▆ ▅  ▄  ▂  ▂ ▄  ▄  ▃  ▃ ▂  ▂  ▂  ▁              ▂
  ▅▁█▁▁█▁▁█▁▁█▁█▁▁█▁▁█▁▁█▁█▁▁█▁▁█▁▁█▁█▁▁█▁▁█▁▁█▁█▁▁▇▁▁█▁▁▇▁▄ █
  5.75 ns      Histogram: log(frequency) by time     6.62 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> (@macroexpand @einsum A[i,j] * B[k,l] * C[j,k] * D[l,i]) ==
       (@macroexpand @einsum A[i,j] * C[j,k] * B[k,l] * D[l,i])
false
```

This PR:

```Julia
julia> using Tensorial

julia> using BenchmarkTools

julia> A = rand(Mat{3,3});

julia> B = rand(Mat{3,3});

julia> C = rand(Mat{3,3});

julia> D = rand(Mat{3,3});

julia> @benchmark @einsum $(Ref(A))[][i,j] * $(Ref(B))[][k,l] * $(Ref(C))[][j,k] * $(Ref(D))[][l,i]
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  5.875 ns … 45.458 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.042 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.066 ns ±  0.684 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

           ▂         █    ▂
  ▂▁▁▁▇▁▁▁▁█▁▁▁▁▃▁▁▁▁█▁▁▁▁█▁▁▁▅▁▁▁▁▄▁▁▁▁▃▁▁▁▁▂▁▁▁▁▂▁▁▁▁▂▁▁▁▂ ▂
  5.88 ns        Histogram: frequency by time        6.38 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark @einsum $(Ref(A))[][i,j] * $(Ref(C))[][j,k] * $(Ref(B))[][k,l] * $(Ref(D))[][l,i]
BenchmarkTools.Trial: 10000 samples with 999 evaluations per sample.
 Range (min … max):  5.631 ns … 74.324 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.590 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.956 ns ±  2.409 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▆▅█   ▇  ▃    ▂
  ▆███▆▂▂█▂▂█▃▂▂▃█▂▂▂▂█▃▂▂▁▁▁▂▇▂▂▂▁▂▁▁▂▂▁▁▁▂▁▂▁▁▁▁▂▂▁▁▁▂▂▂▁▂ ▃
  5.63 ns        Histogram: frequency by time        13.4 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> (@macroexpand @einsum A[i,j] * B[k,l] * C[j,k] * D[l,i]) ==
       (@macroexpand @einsum A[i,j] * C[j,k] * B[k,l] * D[l,i])
true
```