### PR TITLE
Refine rotation APIs and fix Euler sequence handling

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -647,7 +647,7 @@ true
 function rotmat(θ::Vec{3}; sequence::Symbol)
     @inbounds α, β, γ = θ[1], θ[2], θ[3]
     # intrinsic
-    sequence == :XZX && return rotmatx(α) * rotmaty(β) * rotmatz(γ)
+    sequence == :XZX && return rotmatx(α) * rotmatz(β) * rotmatx(γ)
     sequence == :XYX && return rotmatx(α) * rotmaty(β) * rotmatx(γ)
     sequence == :YXY && return rotmaty(α) * rotmatx(β) * rotmaty(γ)
     sequence == :YZY && return rotmaty(α) * rotmatz(β) * rotmaty(γ)
@@ -660,7 +660,7 @@ function rotmat(θ::Vec{3}; sequence::Symbol)
     sequence == :ZYX && return rotmatz(α) * rotmaty(β) * rotmatx(γ)
     sequence == :ZXY && return rotmatz(α) * rotmatx(β) * rotmaty(γ)
     # extrinsic
-    sequence == :xzx && return rotmatx(γ) * rotmaty(β) * rotmatz(α)
+    sequence == :xzx && return rotmatx(γ) * rotmatz(β) * rotmatx(α)
     sequence == :xyx && return rotmatx(γ) * rotmaty(β) * rotmatx(α)
     sequence == :yxy && return rotmaty(γ) * rotmatx(β) * rotmaty(α)
     sequence == :yzy && return rotmaty(γ) * rotmatz(β) * rotmaty(α)
@@ -744,8 +744,10 @@ end
 """
     rotmat(a => b)
 
-Construct rotation matrix rotating vector `a` to `b`.
-The norms of two vectors must be the same.
+Construct the minimal rotation matrix that maps vector `a` to vector `b`.
+The norms of the two vectors must be the same.
+For antiparallel vectors, where the rotation axis is not unique, a deterministic
+axis orthogonal to `a` is chosen.
 
 # Examples
 ```jldoctest
@@ -763,23 +765,75 @@ julia> b = normalize(rand(Vec{3}))
 
 julia> R = rotmat(a => b)
 3×3 Tensor{Tuple{3, 3}, Float64, 2, 9}:
- -0.00540771   0.853773   0.520617
-  0.853773    -0.267108   0.446905
-  0.520617     0.446905  -0.727485
+  0.836709  0.546409   0.0368198
+ -0.525517  0.819999  -0.22679
+ -0.154112  0.170408   0.973247
 
 julia> R * a ≈ b
 true
 ```
 """
-function rotmat(pair::Pair{Vec{dim, T}, Vec{dim, T}})::Mat{dim, dim, T} where {dim, T}
-    # https://math.stackexchange.com/questions/180418/calculate-rotation-matrix-to-align-vector-a-to-vector-b-in-3d/2672702#2672702
+@inline function _same_norm2(a²::T, b²::T) where {T <: AbstractFloat}
+    tol = sqrt(eps(T)) * max(abs(a²), abs(b²))
+    abs(a² - b²) ≤ tol
+end
+@inline _same_norm2(a², b²) = a² == b²
+
+@inline function _orthogonal_unit_vector(a::Vec{dim}) where {dim}
+    _, i = findmin(abs.(Tuple(a)))
+    e = Vec(ntuple(j -> ifelse(j == i, one(eltype(a)), zero(eltype(a))), Val(dim)))
+    normalize(e - (e ⋅ a) / (a ⋅ a) * a)
+end
+
+@inline _antiparallel_rotmat(a::Vec{1, T}) where {T} = -one(Mat{1, 1, T})
+@inline function _antiparallel_rotmat(a::Vec{dim, T}) where {dim, T}
+    u_outer = (a ⊗ a) / (a ⋅ a)
+    w = _orthogonal_unit_vector(a)
+    one(Mat{dim, dim, T}) - 2u_outer - 2(w ⊗ w)
+end
+
+function rotmat(pair::Pair{Vec{2, T}, Vec{2, T}})::Mat{2, 2, T} where {T}
     a = pair.first
     b = pair.second
-    contract1(a, a) ≈ contract1(b, b) || throw(ArgumentError("the norms of two vectors must be the same"))
-    a ==  b && return  one(Mat{dim, dim, T})
-    a == -b && return -one(Mat{dim, dim, T})
-    c = a + b
-    2 * (c ⊗ c) / (c ⋅ c) - one(Mat{dim, dim, T})
+    a² = a ⋅ a
+    b² = b ⋅ b
+    _same_norm2(a², b²) || throw(ArgumentError("the norms of two vectors must be the same"))
+    iszero(a²) && return one(Mat{2, 2, T})
+    cosθ = (a ⋅ b) / a²
+    sinθ = (a × b) / a²
+    @Mat [cosθ -sinθ
+          sinθ  cosθ]
+end
+
+function rotmat(pair::Pair{Vec{3, T}, Vec{3, T}})::Mat{3, 3, T} where {T}
+    a = pair.first
+    b = pair.second
+    a² = a ⋅ a
+    b² = b ⋅ b
+    _same_norm2(a², b²) || throw(ArgumentError("the norms of two vectors must be the same"))
+    iszero(a²) && return one(Mat{3, 3, T})
+    n = a × b
+    n² = n ⋅ n
+    if iszero(n²)
+        return a ⋅ b < zero(T) ? _antiparallel_rotmat(a) : one(Mat{3, 3, T})
+    end
+    n_norm = sqrt(n²)
+    rotmat(atan(n_norm, a ⋅ b), n / n_norm)
+end
+
+function rotmat(pair::Pair{Vec{dim, T}, Vec{dim, T}})::Mat{dim, dim, T} where {dim, T}
+    a = pair.first
+    b = pair.second
+    a² = a ⋅ a
+    b² = b ⋅ b
+    _same_norm2(a², b²) || throw(ArgumentError("the norms of two vectors must be the same"))
+    iszero(a²) && return one(Mat{dim, dim, T})
+    c = (a ⋅ b) / a²
+    c == one(c) && return one(Mat{dim, dim, T})
+    c == -one(c) && return _antiparallel_rotmat(a)
+    K = (b ⊗ a - a ⊗ b) / a²
+    I = one(Mat{dim, dim, T})
+    I + K + K * K / (one(c) + c)
 end
 
 """
@@ -844,19 +898,53 @@ julia> rotate(A, R) ≈ R * A * R'
 true
 ```
 """
-@inline rotate(v::Vec, R::SecondOrderTensor) = R * v
-@inline rotate(v::Vec{2}, R::SecondOrderTensor{3}) = rotate(vcat(v,0), R) # extend to 3d vector, then rotate it
-@inline rotate(A::SecondOrderTensor, R::SecondOrderTensor) = R * A * R'
+@inline rotate(v::Vec{dim}, R::SecondOrderTensor{dim}) where {dim} = R * v
+@inline rotate(A::SecondOrderTensor{dim}, R::SecondOrderTensor{dim}) where {dim} = R * A * R'
 @inline function rotate(A::SymmetricSecondOrderTensor{dim}, R::SecondOrderTensor{dim}) where {dim}
     ARᵀ = contract(A, R, Val(2), Val(2))
     contract(SymmetricSecondOrderTensor{dim}, R, ARᵀ, Val(2), Val(1))
 end
 
-function angleaxis(R::SecondOrderTensor{3})
-    # https://math.stackexchange.com/questions/893984/conversion-of-rotation-matrix-to-quaternion
-    θ = acos((tr(R)-1) / 2)
-    n = Tensor(Real.(eigvecs(SArray(R))[:,3]))
-    θ, n
+function _rotation_axis_at_pi(R::SecondOrderTensor{3})
+    T = eltype(R)
+    half = inv(T(2))
+    x² = max((R[1,1] + one(T)) * half, zero(T))
+    y² = max((R[2,2] + one(T)) * half, zero(T))
+    z² = max((R[3,3] + one(T)) * half, zero(T))
+    if x² ≥ y² && x² ≥ z²
+        x = sqrt(x²)
+        y = (R[1,2] + R[2,1]) / 4x
+        z = (R[1,3] + R[3,1]) / 4x
+    elseif y² ≥ z²
+        y = sqrt(y²)
+        x = (R[1,2] + R[2,1]) / 4y
+        z = (R[2,3] + R[3,2]) / 4y
+    else
+        z = sqrt(z²)
+        x = (R[1,3] + R[3,1]) / 4z
+        y = (R[2,3] + R[3,2]) / 4z
+    end
+    normalize(Vec(x, y, z))
+end
+
+"""
+    angleaxis(R::SecondOrderTensor{3})
+
+Convert a 3D rotation matrix to an angle-axis pair `(θ, n)`.
+`R` is assumed to be a rotation matrix; orthogonality and determinant are not
+validated.
+"""
+function angleaxis(R::SecondOrderTensor{3, T}) where {T}
+    cosθ = clamp((tr(R) - one(T)) / 2, -one(T), one(T))
+    θ = acos(cosθ)
+    if cosθ == one(cosθ)
+        return θ, Vec(one(θ), zero(θ), zero(θ))
+    elseif cosθ == -one(cosθ)
+        return θ, _rotation_axis_at_pi(R)
+    end
+    sinθ = sin(θ)
+    n = Vec(R[3,2] - R[2,3], R[1,3] - R[3,1], R[2,1] - R[1,2]) / (2sinθ)
+    θ, normalize(n)
 end
 
 # exp/log

--- a/test/ops.jl
+++ b/test/ops.jl
@@ -229,10 +229,45 @@ end
             α = deg2rad(T(10))
             β = deg2rad(T(20))
             γ = deg2rad(T(30))
+            θ = Vec(α, β, γ)
+            intrinsic = (
+                :XZX => rotmatx(α) * rotmatz(β) * rotmatx(γ),
+                :XYX => rotmatx(α) * rotmaty(β) * rotmatx(γ),
+                :YXY => rotmaty(α) * rotmatx(β) * rotmaty(γ),
+                :YZY => rotmaty(α) * rotmatz(β) * rotmaty(γ),
+                :ZYZ => rotmatz(α) * rotmaty(β) * rotmatz(γ),
+                :ZXZ => rotmatz(α) * rotmatx(β) * rotmatz(γ),
+                :XZY => rotmatx(α) * rotmatz(β) * rotmaty(γ),
+                :XYZ => rotmatx(α) * rotmaty(β) * rotmatz(γ),
+                :YXZ => rotmaty(α) * rotmatx(β) * rotmatz(γ),
+                :YZX => rotmaty(α) * rotmatz(β) * rotmatx(γ),
+                :ZYX => rotmatz(α) * rotmaty(β) * rotmatx(γ),
+                :ZXY => rotmatz(α) * rotmatx(β) * rotmaty(γ),
+            )
+            extrinsic = (
+                :xzx => rotmatx(γ) * rotmatz(β) * rotmatx(α),
+                :xyx => rotmatx(γ) * rotmaty(β) * rotmatx(α),
+                :yxy => rotmaty(γ) * rotmatx(β) * rotmaty(α),
+                :yzy => rotmaty(γ) * rotmatz(β) * rotmaty(α),
+                :zyz => rotmatz(γ) * rotmaty(β) * rotmatz(α),
+                :zxz => rotmatz(γ) * rotmatx(β) * rotmatz(α),
+                :xzy => rotmaty(γ) * rotmatz(β) * rotmatx(α),
+                :xyz => rotmatz(γ) * rotmaty(β) * rotmatx(α),
+                :yxz => rotmatz(γ) * rotmatx(β) * rotmaty(α),
+                :yzx => rotmatx(γ) * rotmatz(β) * rotmaty(α),
+                :zyx => rotmatx(γ) * rotmaty(β) * rotmatz(α),
+                :zxy => rotmaty(γ) * rotmatx(β) * rotmatz(α),
+            )
+            for (sequence, expected) in (intrinsic..., extrinsic...)
+                @test (@inferred rotmat(θ, sequence = sequence))::Mat{3,3,T} ≈ expected
+            end
             for (XYZ, zyx) in ((:XZX, :xzx), (:XYX, :xyx), (:YXY, :yxy), (:YZY, :yzy), (:ZYZ, :zyz), (:ZXZ, :zxz),
                                (:XZY, :yzx), (:XYZ, :zyx), (:YXZ, :zxy), (:YZX, :xzy), (:ZYX, :xyz), (:ZXY, :yxz))
                 @test (@inferred rotmat(Vec(α,β,γ), sequence = XYZ))::Mat{3,3,T} ≈ (@inferred rotmat(Vec(γ,β,α), sequence = zyx))::Mat{3,3,T}
             end
+            @test_throws ArgumentError rotmat(θ, sequence = :XXY)
+            @test_throws ArgumentError rotmat(θ, sequence = :XyZ)
+            @test_throws ArgumentError rotmat(θ, sequence = :XY)
             # 2D/3D rotmat
             @test (@inferred rotmat(α)) ≈ (@inferred rotmatx(α))[[2,3], [2,3]]
             @test (@inferred rotmat(α)) ≈ (@inferred rotmaty(α))[[3,1], [3,1]]
@@ -240,8 +275,28 @@ end
             for dim in (2, 3)
                 a = normalize(rand(Vec{dim, T}))
                 b = normalize(rand(Vec{dim, T}))
-                @test (@inferred rotmat(a => b))::Mat{dim, dim, T} * a ≈ b
+                R = (@inferred rotmat(a => b))::Mat{dim, dim, T}
+                @test R * a ≈ b
+                @test R' * R ≈ one(Mat{dim, dim, T})
+                @test det(R) ≈ one(T)
             end
+            @test (@inferred rotmat(Vec{2, T}(1,0) => Vec{2, T}(0,1)))::Mat{2,2,T} ≈ rotmat(T(π/2))
+            Rπ2 = (@inferred rotmat(Vec{2, T}(1,0) => Vec{2, T}(-1,0)))::Mat{2,2,T}
+            @test Rπ2 ≈ rotmat(T(π))
+            @test det(Rπ2) ≈ one(T)
+            @test (@inferred rotmat(Vec{3, T}(1,0,0) => Vec{3, T}(0,1,0)))::Mat{3,3,T} ≈ rotmatz(T(π/2))
+            a = normalize(Vec{3, T}(1,2,3))
+            Rπ3 = (@inferred rotmat(a => -a))::Mat{3,3,T}
+            @test Rπ3 * a ≈ -a
+            @test Rπ3' * Rπ3 ≈ one(Mat{3,3,T})
+            @test det(Rπ3) ≈ one(T)
+            @test (@inferred rotmat(Vec{1, T}(1) => Vec{1, T}(-1)))::Mat{1,1,T} ≈ -one(Mat{1,1,T})
+            a4 = Vec{4, T}(1,0,0,0)
+            b4 = Vec{4, T}(0,1,0,0)
+            R4 = (@inferred rotmat(a4 => b4))::Mat{4,4,T}
+            @test R4 * a4 ≈ b4
+            @test R4' * R4 ≈ one(Mat{4,4,T})
+            @test det(R4) ≈ one(T)
             @test (@inferred rotmat(T(π/3), Vec{3, T}(0,0,1)))::Mat{3,3,T} * Vec(1,0,0) ≈ [cos(π/3), sin(π/3), 0]
         end
         @test_throws Exception rotmat(Vec(1,0) => Vec(1,1)) # length of two vectors must be the same
@@ -255,20 +310,32 @@ end
                 v = rand(Vec{dim, T})
                 A = rand(SecondOrderTensor{dim, T})
                 S = rand(SymmetricSecondOrderTensor{dim, T})
-                @test (@inferred rotate(v, R))::Vec{dim, T} ≈ v ⊡ R
+                @test (@inferred rotate(v, R))::Vec{dim, T} ≈ Tensor(SArray(R) * SArray(v))
                 @test (@inferred rotate(A, R))::SecondOrderTensor{dim, T} ≈ R * A * R'
                 @test (@inferred rotate(S, R))::SymmetricSecondOrderTensor{dim, T} ≈ R * S * R'
             end
-            # v in 2D, R in 3D
+            # v in 2D, R in 3D must be lifted explicitly.
             for R in (rotmatx(T(π/4)), rotmaty(T(π/4)), rotmatz(T(π/4)))
                 v = rand(Vec{2, T})
-                @test (@inferred rotate(v, R))::Vec{3, T} ≈ rotate(v, quaternion(angleaxis(R)...))
+                v3 = vcat(v, zero(T))
+                @test_throws MethodError rotate(v, R)
+                @test (@inferred rotate(v3, R))::Vec{3, T} ≈ rotate(v3, quaternion(angleaxis(R)...))
             end
         end
     end
     @testset "angleaxis" begin
         Random.seed!(1234)
         for T in (Float32, Float64)
+            R = one(Mat{3,3,T})
+            θ, n = (@inferred angleaxis(R))::Tuple{T, Vec{3,T}}
+            @test θ ≈ zero(T)
+            @test rotmat(θ, n) ≈ R
+            for axis in (Vec{3,T}(1,0,0), Vec{3,T}(0,1,0), Vec{3,T}(0,0,1))
+                R = rotmat(T(π), axis)
+                θ, n = (@inferred angleaxis(R))::Tuple{T, Vec{3,T}}
+                @test θ ≈ T(π)
+                @test rotmat(θ, n) ≈ R
+            end
             a = normalize(rand(Vec{3, T}))
             b = normalize(rand(Vec{3, T}))
             R = rotmat(a => b)


### PR DESCRIPTION
## Summary

- Fix `:XZX` / `:xzx` Euler sequence construction in `rotmat`
- Redefine `rotmat(a => b)` as the minimal rotation mapping `a` to `b`
- Remove implicit `Vec{2}` lifting in `rotate(v, R::SecondOrderTensor{3})`
- Document that `angleaxis(R)` assumes `R` is already a rotation matrix
- Add regression tests for Euler sequences, minimal rotations, antiparallel vectors, and explicit 2D-to-3D lifting

## Breaking Change

This changes rotation API behavior:

- `rotmat(a => b)` now returns the minimal rotation from `a` to `b`; previously the 3D implementation returned a half-turn around `a + b`.
- `rotate(v::Vec{2}, R::SecondOrderTensor{3})` is no longer supported. Lift explicitly with `vcat(v, 0)` before applying a 3D rotation.