### PR TITLE
Add generic spectral functions

### DIFF
--- a/docs/src/API reference.md
+++ b/docs/src/API reference.md
@@ -106,6 +106,7 @@ Base.log(::Quaternion)
 ## Spectral functions
 
 ```@docs
+spectral
 Base.sqrt(::Tensorial.AbstractSymmetricSecondOrderTensor)
 Base.exp(::Tensorial.AbstractSymmetricSecondOrderTensor)
 Base.log(::Tensorial.AbstractSymmetricSecondOrderTensor)

--- a/docs/src/Operations.md
+++ b/docs/src/Operations.md
@@ -135,6 +135,13 @@ sqrt(one(SymmetricSecondOrderTensor{3})) ≈ one(SymmetricSecondOrderTensor{3})
 exp(zero(SymmetricSecondOrderTensor{3})) ≈ one(SymmetricSecondOrderTensor{3})
 ```
 
+Use [`spectral`](@ref) to apply another scalar function to the eigenvalues:
+
+```@repl operations
+S = symmetric(A' * A)
+spectral(x -> x^2 + 2x, S) ≈ S^2 + 2S
+```
+
 For operation docstrings, see [Core operations](@ref),
 [Continuum mechanics API](@ref), [Rotations and quaternions](@ref), and
 [Spectral functions](@ref).

--- a/src/Tensorial.jl
+++ b/src/Tensorial.jl
@@ -68,6 +68,7 @@ export
     rotmaty,
     rotmatz,
     rotate,
+    spectral,
 # directsum
     ⊕,
     pack,

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -954,15 +954,31 @@ function angleaxis(R::SecondOrderTensor{3, T}) where {T}
     θ, normalize(n)
 end
 
-# sqrt/exp/log
-@inline _scalar_derivative(::typeof(sqrt), x) = inv(2sqrt(x))
-@inline _scalar_derivative(::typeof(log), x) = inv(x)
-@inline _scalar_derivative(::typeof(exp), x) = exp(x)
+@inline _sinhc(x) = x == zero(x) ? one(x) : sinh(x) / x
+@inline _atanhc(x) = x == zero(x) ? one(x) : atanh(x) / x
 
-@inline function _divided_difference(op, x, y)
-    x == y && return _scalar_derivative(op, x)
+# StaticArrays' 3x3 symmetric eigensolver can split an exactly repeated
+# eigenvalue by a few ulps after rotations. The margin below is deliberately
+# narrow: rank-one projector cases reached 6 ulps in stress checks, so 16 ulps
+# covers that with room for platform noise without treating broadly separated
+# eigenvalues as repeated. See the testset "spectral repeated eigenvalue
+# tolerance" for the cases that keep this choice anchored.
+@inline _spectral_repeated_eigenvalue_tol_factor() = 16
+@inline _spectral_repeated_eigenvalue_tol(scale) = _spectral_repeated_eigenvalue_tol_factor() * eps(scale)
+
+@inline _spectral_scale(λ) = max(one(eltype(λ)), maximum(abs, λ))
+
+@inline function _divided_difference(op, dop, x, y, scale)
+    x == y && return dop(x)
+    abs(x - y) ≤ _spectral_repeated_eigenvalue_tol(scale) && return dop((x + y) / 2)
     (op(x) - op(y)) / (x - y)
 end
+
+@inline _divided_difference(::typeof(sqrt), _dop, x, y, _scale) = inv(sqrt(x) + sqrt(y))
+@inline _divided_difference(::typeof(exp), _dop, x, y, _scale) = exp((x + y) / 2) * _sinhc((x - y) / 2)
+@inline _divided_difference(::typeof(log), _dop, x, y, _scale) = _atanhc((x - y) / (x + y)) / ((x + y) / 2)
+
+@inline _scalar_derivative(f) = x -> ∂(f, x)
 
 @inline function _spectral_decomposition(A::AbstractSymmetricSecondOrderTensor)
     F = eigen(A)
@@ -979,8 +995,13 @@ end
     _spectral_value(op, λ, Q)
 end
 
-@inline function _spectral_derivative(op, λ::AbstractVec{dim}, Q::AbstractSecondOrderTensor{dim}) where {dim}
-    G = Mat{dim, dim}((a, b) -> @inbounds _divided_difference(op, λ[a], λ[b]))
+@inline function _spectral_derivative(op, dop, λ::AbstractVec{dim}, Q::AbstractSecondOrderTensor{dim}) where {dim}
+    scale = _spectral_scale(λ)
+    G = Mat{dim, dim}((a, b) -> @inbounds _divided_difference(op, dop, λ[a], λ[b], scale))
+    _spectral_derivative(G, Q)
+end
+
+@inline function _spectral_derivative(G::AbstractSecondOrderTensor{dim}, Q::AbstractSecondOrderTensor{dim}) where {dim}
     SymmetricFourthOrderTensor{dim}(
         @inline function(i, j, k, l)
             sum(
@@ -996,11 +1017,37 @@ end
 @inline _chain_spectral_derivative(dydA, dAdx::Tensor) = dydA ⊡₂ dAdx
 @inline _chain_spectral_derivative(dydA, dAdxs::Tuple) = map(dAdx -> _chain_spectral_derivative(dydA, dAdx), dAdxs)
 
-@inline function _spectral_dual(op, A::AbstractSymmetricSecondOrderTensor{dim, <: Dual{Tg, Tv, N}}) where {dim, F, V, Tg <: Tag{F,V}, Tv <: Real, N}
+"""
+    spectral(f, A::AbstractSymmetricSecondOrderTensor)
+    spectral(f, df, A::AbstractSymmetricSecondOrderTensor)
+
+Apply the scalar function `f` to the eigenvalues of a symmetric second-order
+tensor `A`.
+
+For an eigendecomposition,
+
+```math
+\\bm{A} = \\bm{Q} \\operatorname{diag}(\\lambda_i) \\bm{Q}^\\mathsf{T},
+\\quad
+f(\\bm{A}) = \\bm{Q} \\operatorname{diag}(f(\\lambda_i)) \\bm{Q}^\\mathsf{T}.
+```
+
+The result is a `SymmetricSecondOrderTensor`. Automatic differentiation is
+defined as a spectral tensor function. When eigenvalues are repeated,
+`spectral(f, A)` computes the scalar derivative of `f` with Tensorial's
+automatic differentiation. Use `spectral(f, df, A)` to provide the scalar
+derivative explicitly.
+"""
+function spectral end
+
+@inline spectral(f, A::AbstractSymmetricSecondOrderTensor) = _spectral_value(f, A)
+@inline spectral(f, df, A::AbstractSymmetricSecondOrderTensor) = spectral(f, A)
+@inline spectral(f, A::AbstractSymmetricSecondOrderTensor{dim, <: Dual{Tg, Tv, N}}) where {dim, F, V, Tg <: Tag{F,V}, Tv <: Real, N} = spectral(f, _scalar_derivative(f), A)
+@inline function spectral(f, df, A::AbstractSymmetricSecondOrderTensor{dim, <: Dual{Tg, Tv, N}}) where {dim, F, V, Tg <: Tag{F,V}, Tv <: Real, N}
     A₀ = extract_value(A)
     λ, Q = _spectral_decomposition(A₀)
-    y = _spectral_value(op, λ, Q)
-    dydA = _spectral_derivative(op, λ, Q)
+    y = _spectral_value(f, λ, Q)
+    dydA = _spectral_derivative(f, df, λ, Q)
     dAdx = extract_gradient(A, _zero_primal(V))
     create_dual(Tg(), y, _chain_spectral_derivative(dydA, dAdx))
 end
@@ -1021,7 +1068,7 @@ For an eigendecomposition,
 The result is a `SymmetricSecondOrderTensor`. Automatic differentiation is
 defined as a spectral tensor function, including repeated eigenvalues.
 """
-@inline Base.sqrt(x::AbstractSymmetricSecondOrderTensor) = _spectral_value(sqrt, x)
+@inline Base.sqrt(x::AbstractSymmetricSecondOrderTensor) = spectral(sqrt, x)
 
 """
     exp(A::AbstractSymmetricSecondOrderTensor)
@@ -1039,7 +1086,7 @@ For an eigendecomposition,
 The result is a `SymmetricSecondOrderTensor`. Automatic differentiation is
 defined as a spectral tensor function, including repeated eigenvalues.
 """
-@inline Base.exp(x::AbstractSymmetricSecondOrderTensor) = _spectral_value(exp, x)
+@inline Base.exp(x::AbstractSymmetricSecondOrderTensor) = spectral(exp, x)
 
 """
     log(A::AbstractSymmetricSecondOrderTensor)
@@ -1057,10 +1104,7 @@ For an eigendecomposition,
 The result is a `SymmetricSecondOrderTensor`. Automatic differentiation is
 defined as a spectral tensor function, including repeated eigenvalues.
 """
-@inline Base.log(x::AbstractSymmetricSecondOrderTensor) = _spectral_value(log, x)
-@inline Base.sqrt(x::AbstractSymmetricSecondOrderTensor{dim, <: Dual{Tg, Tv, N}}) where {dim, F, V, Tg <: Tag{F,V}, Tv <: Real, N} = _spectral_dual(sqrt, x)
-@inline Base.exp(x::AbstractSymmetricSecondOrderTensor{dim, <: Dual{Tg, Tv, N}}) where {dim, F, V, Tg <: Tag{F,V}, Tv <: Real, N} = _spectral_dual(exp, x)
-@inline Base.log(x::AbstractSymmetricSecondOrderTensor{dim, <: Dual{Tg, Tv, N}}) where {dim, F, V, Tg <: Tag{F,V}, Tv <: Real, N} = _spectral_dual(log, x)
+@inline Base.log(x::AbstractSymmetricSecondOrderTensor) = spectral(log, x)
 
 # ----------------------------------------------#
 # operations calling methods in StaticArrays.jl #

--- a/test/ops.jl
+++ b/test/ops.jl
@@ -348,6 +348,9 @@ end
     end
     @testset "sqrt/exp/log" begin
         divdiff(f, df, x, y) = x == y ? df(x) : (f(x) - f(y)) / (x - y)
+        poly(x) = x^3 + 2x
+        dpoly(x) = 3x^2 + 2
+        generic_log(x) = log(x)
         for T in (Float32, Float64)
             for dim in (2, 3)
                 x = rand(SymmetricSecondOrderTensor{dim, T})
@@ -374,15 +377,20 @@ end
                 Dlog = (@inferred gradient(log, y))::SymmetricFourthOrderTensor{dim, T}
                 dY = (@inferred Dexp ⊡₂ H)::SymmetricSecondOrderTensor{dim, T}
                 @test (@inferred Dlog ⊡₂ dY)::SymmetricSecondOrderTensor{dim, T} ≈ H rtol=sqrt(eps(T)) atol=sqrt(eps(T))
+                @test (@inferred spectral(poly, C))::SymmetricSecondOrderTensor{dim, T} ≈ C^3 + 2C
+                @test (@inferred spectral(poly, dpoly, C))::SymmetricSecondOrderTensor{dim, T} ≈ C^3 + 2C
+                Dpoly = (@inferred gradient(A -> spectral(poly, A), C))::SymmetricFourthOrderTensor{dim, T}
+                Dpoly_explicit = (@inferred gradient(A -> spectral(poly, dpoly, A), C))::SymmetricFourthOrderTensor{dim, T}
+                @test Dpoly ≈ Dpoly_explicit
             end
         end
         for T in (Float32, Float64)
             λ = Vec{3, T}(2, 2, 3)
             C = SymmetricSecondOrderTensor{3, T}((i, j) -> i == j ? λ[i] : zero(T))
             H = SymmetricSecondOrderTensor{3, T}(0.2, 0.3, -0.1, -0.4, 0.5, 0.6)
-            for (f, df) in ((sqrt, x -> inv(2sqrt(x))), (log, inv), (exp, exp))
+            for (f, df) in ((sqrt, x -> inv(2sqrt(x))), (log, inv), (exp, exp), (poly, dpoly))
                 expected = SymmetricSecondOrderTensor{3, T}((i, j) -> divdiff(f, df, λ[i], λ[j]) * H[i,j])
-                D = gradient(f, C)
+                D = f === poly ? gradient(A -> spectral(f, A), C) : gradient(f, C)
                 @test D isa SymmetricFourthOrderTensor{3, T}
                 @test (D ⊡₂ H)::SymmetricSecondOrderTensor{3, T} ≈ expected rtol=sqrt(eps(T)) atol=sqrt(eps(T))
             end
@@ -395,6 +403,41 @@ end
             fd = (f(C + ε * H) - f(C - ε * H)) / (2ε)
             @test all(isfinite, Tuple(D))
             @test D ⊡₂ H ≈ fd rtol=1e-5 atol=1e-6
+        end
+        @testset "spectral repeated eigenvalue tolerance" begin
+            @test Tensorial._spectral_repeated_eigenvalue_tol_factor() == 16
+            cases = (
+                (Float32, Float32(100), Vec{3, Float32}(-1.6006851, 0.55908036, -0.028148232)),
+                (Float64, 100.0, Vec(0.9529424983699967, -1.333610706246097, 0.45111839663929376)),
+                (Float64, 1.0e8, Vec(0.267689506816948, 0.17903522287287554, -1.095730985293828)),
+            )
+            for (T, μ, v) in cases
+                P = SymmetricSecondOrderTensor{3, T}((i, j) -> v[i] * v[j] / dot(v, v))
+                C = μ * one(SymmetricSecondOrderTensor{3, T}) - (μ - one(T)) * P
+                λ, Q = eigen(C)
+                scale = max(abs(λ[1]), abs(λ[2]), abs(λ[3]), one(T))
+                gap = abs(λ[3] - λ[2])
+                split = gap / eps(scale)
+                H = SymmetricSecondOrderTensor{3, T}((i, j) -> Q[i,2] * Q[j,3] + Q[i,3] * Q[j,2])
+                @test λ ≈ Vec(one(T), μ, μ)
+                @test split ≤ Tensorial._spectral_repeated_eigenvalue_tol_factor()
+                nextμ = nextfloat(μ)
+                @test Tensorial._divided_difference(generic_log, inv, μ, nextμ, scale) == inv((μ + nextμ) / 2)
+                D = gradient(A -> spectral(generic_log, inv, A), C)
+                @test D ⊡₂ H ≈ inv(μ) * H rtol=sqrt(eps(T)) atol=sqrt(eps(T))
+                D = gradient(A -> spectral(sqrt, A), C)
+                @test D ⊡₂ H ≈ inv(2sqrt(μ)) * H rtol=sqrt(eps(T)) atol=sqrt(eps(T))
+            end
+            v = Vec(0.3, -0.7, 1.2)
+            P = SymmetricSecondOrderTensor{3}((i, j) -> v[i] * v[j] / dot(v, v))
+            C = 100.0 * one(SymmetricSecondOrderTensor{3}) - 99.0 * P
+            λ, Q = eigen(C)
+            H = SymmetricSecondOrderTensor{3}((i, j) -> Q[i,2] * Q[j,3] + Q[i,3] * Q[j,2])
+            @test λ ≈ Vec(1.0, 100.0, 100.0)
+            for (f, df) in ((sqrt, x -> inv(2sqrt(x))), (log, inv), (exp, exp), (poly, dpoly))
+                D = gradient(A -> spectral(f, A), C)
+                @test D ⊡₂ H ≈ df(100.0) * H rtol=1e-12 atol=1e-12
+            end
         end
     end
 end


### PR DESCRIPTION
Adds a generic `spectral(f, A)` API for symmetric second-order tensors and supports AD through the spectral derivative. Stabilizes divided differences for repeated eigenvalues, including specialized `sqrt`/`log`/`exp` formulas.