### PR TITLE
Refine quaternion behavior

### DIFF
--- a/docs/src/API reference.md
+++ b/docs/src/API reference.md
@@ -100,6 +100,7 @@ angleaxis
 Quaternion
 quaternion
 Base.exp(::Quaternion)
+Base.sqrt(::Quaternion)
 Base.log(::Quaternion)
 ```
 

--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -22,33 +22,27 @@ See also [`quaternion`](@ref).
 """
 struct Quaternion{T} <: Number
     data::NTuple{4, T}
-    function Quaternion{T}(data::NTuple{4, Real}) where {T}
+    function Quaternion{T}(data::NTuple{4, Number}) where {T}
+        T <: Complex && throw(ArgumentError("complex-valued quaternions are not supported"))
         new{T}(convert_ntuple(T, data))
     end
 end
 
 @inline Quaternion(data::NTuple{4, Any}) = Quaternion{promote_ntuple_eltype(data)}(data)
-@inline (::Type{T})(data::Vararg{Any}) where {T <: Quaternion} = T(data)
-
-@inline _quaternion_vec3(v::Vec{2}) = @inbounds Vec(v[1], v[2], zero(eltype(v)))
-@inline _quaternion_vec3(v::Vec{1}) = @inbounds Vec(v[1], zero(eltype(v)), zero(eltype(v)))
+@inline (::Type{T})(a, b, c, d) where {T <: Quaternion} = T((a, b, c, d))
 
 # from scalar and vector
-@inline Quaternion{T}(r::Real, v::Vec{3}) where {T} = @inbounds Quaternion{T}(r, v[1], v[2], v[3])
-@inline Quaternion{T}(r::Real, v::Vec{2}) where {T} = Quaternion{T}(r, _quaternion_vec3(v))
-@inline Quaternion{T}(r::Real, v::Vec{1}) where {T} = Quaternion{T}(r, _quaternion_vec3(v))
-@inline Quaternion(r::Real, v::Vec) = Quaternion{promote_type(typeof(r), eltype(v))}(r, v)
+@inline Quaternion{T}(r::Number, v::Vec{3}) where {T} = @inbounds Quaternion{T}(r, v[1], v[2], v[3])
+@inline Quaternion(r::Number, v::Vec{3}) = Quaternion{promote_type(typeof(r), eltype(v))}(r, v)
 
 # from vector
 @inline Quaternion{T}(v::Vec{4}) where {T} = Quaternion{T}(Tuple(v))
-for dim in 1:3
-    @eval @inline Quaternion{T}(v::Vec{$dim}) where {T} = Quaternion{T}(zero(eltype(v)), v)
-end
+@inline Quaternion{T}(v::Vec{3}) where {T} = Quaternion{T}(zero(eltype(v)), v)
 @inline Quaternion(v::Vec) = Quaternion{eltype(v)}(v)
 
 # from scalar
-@inline Quaternion{T}(r::Real) where {T} = (z = zero(r); Quaternion{T}(r, z, z, z))
-@inline Quaternion(r::Real) = Quaternion{typeof(r)}(r)
+@inline Quaternion{T}(r::Number) where {T} = (z = zero(r); Quaternion{T}(r, z, z, z))
+@inline Quaternion(r::Number) = Quaternion{typeof(r)}(r)
 
 @inline Vec(q::Quaternion) = Vec(Tuple(q))
 
@@ -65,17 +59,26 @@ Base.propertynames(q::Quaternion) = (:scalar, :vector, :data)
 # conversion
 Base.convert(::Type{Quaternion{T}}, x::Quaternion{T}) where {T} = x
 Base.convert(::Type{Quaternion{T}}, x::Quaternion{U}) where {T, U} = Quaternion(map(T, Tuple(x)))
-Base.convert(::Type{Quaternion{T}}, x::Real) where {T} = convert(Quaternion{T}, Quaternion(x))
+Base.convert(::Type{Quaternion{T}}, x::Number) where {T} = convert(Quaternion{T}, Quaternion(x))
 
 # promotion
-Base.promote_rule(::Type{Quaternion{T}}, ::Type{T}) where {T <: Real} = Quaternion{T}
-Base.promote_rule(::Type{Quaternion{T}}, ::Type{U}) where {T <: Real, U <: Real} = Quaternion{promote_type(T, U)}
-Base.promote_rule(::Type{Quaternion{T}}, ::Type{Quaternion{T}}) where {T <: Real} = Quaternion{T}
-Base.promote_rule(::Type{Quaternion{T}}, ::Type{Quaternion{U}}) where {T <: Real, U <: Real} = Quaternion{promote_type(T, U)}
+Base.promote_rule(::Type{Quaternion{T}}, ::Type{T}) where {T <: Number} = Quaternion{T}
+Base.promote_rule(::Type{Quaternion{T}}, ::Type{U}) where {T <: Number, U <: Number} = Quaternion{promote_type(T, U)}
+Base.promote_rule(::Type{Quaternion{T}}, ::Type{Quaternion{T}}) where {T <: Number} = Quaternion{T}
+Base.promote_rule(::Type{Quaternion{T}}, ::Type{Quaternion{U}}) where {T <: Number, U <: Number} = Quaternion{promote_type(T, U)}
 
 # used for `isapprox`
+Base.zero(::Type{Quaternion{T}}) where {T} = (z = zero(T); Quaternion{T}(z, z, z, z))
+Base.zero(q::Quaternion) = zero(typeof(q))
+Base.one(::Type{Quaternion{T}}) where {T} = (z = zero(T); Quaternion{T}(one(T), z, z, z))
+Base.one(q::Quaternion) = one(typeof(q))
+Base.real(::Type{Quaternion{T}}) where {T} = T
 Base.real(q::Quaternion) = q.scalar
 Base.isfinite(q::Quaternion) = all(isfinite, Tuple(q))
+Base.isinf(q::Quaternion) = any(isinf, Tuple(q))
+Base.isnan(q::Quaternion) = any(isnan, Tuple(q))
+Base.isreal(q::Quaternion) = iszero(q[2]) & iszero(q[3]) & iszero(q[4])
+Base.iszero(q::Quaternion) = iszero(q[1]) & iszero(q[2]) & iszero(q[3]) & iszero(q[4])
 
 """
     quaternion(θ, n::Vec)
@@ -108,10 +111,7 @@ function quaternion(::Type{T}, θ::Real, n::Vec{3}) where {T}
     v = n * sin(ϕ)
     @inbounds Quaternion{T}(cos(ϕ), v)
 end
-quaternion(T::Type, θ::Real, n::Vec{2}) =
-    @inbounds quaternion(T, θ, Vec(n[1], n[2], 0))
-quaternion(θ::Real, n::Vec) =
-    quaternion(promote_type(typeof(θ), eltype(n)), θ, n)
+quaternion(θ::Real, n::Vec) = quaternion(promote_type(typeof(θ), eltype(n)), θ, n)
 
 Base.length(::Quaternion) = 4
 Base.size(::Quaternion) = (4,)
@@ -139,6 +139,9 @@ end
 @inline Base.:*(a::Number, q::Quaternion) = Quaternion(a * Vec(q))
 @inline Base.:*(q::Quaternion, a::Number) = Quaternion(Vec(q) * a)
 @inline Base.:/(q::Quaternion, a::Number) = Quaternion(Vec(q) / a)
+Base.:*(a::Complex, q::Quaternion) = throw(MethodError(*, (a, q)))
+Base.:*(q::Quaternion, a::Complex) = throw(MethodError(*, (q, a)))
+Base.:/(q::Quaternion, a::Complex) = throw(MethodError(/, (q, a)))
 
 # quaternion vs vector
 @inline Base.:*(q::Quaternion, v::Vec) = q * Quaternion(v)
@@ -151,8 +154,14 @@ end
 Convert a quaternion to an angle-axis pair `(θ, n)`.
 """
 function angleaxis(q::Quaternion)
+    iszero(q) && throw(DomainError(q, "zero quaternion does not define a rotation"))
+    q = normalize(q)
+    q.scalar < zero(q.scalar) && (q = -q)
     a = norm(q.vector)
     θ = 2atan(a, q.scalar)
+    if iszero(a)
+        return θ, Vec(one(θ), zero(θ), zero(θ))
+    end
     n = q.vector / a
     θ, n
 end
@@ -177,13 +186,20 @@ julia> rotate(v, quaternion(π/4, Vec(0,0,1)))
  0.0
 ```
 """
-@inline rotate(v::Vec, q::Quaternion) = (q * v / q).vector
+@inline rotate(v::Vec{3}, q::Quaternion) = (q * v / q).vector
 
 @inline Base.conj(q::Quaternion) = Quaternion(q.scalar, -q.vector)
 @inline Base.abs2(q::Quaternion) = (v = Vec(q); contract1(v, v))
-@inline Base.abs(q::Quaternion) = sqrt(abs2(q))
+@inline Base.abs(q::Quaternion) = hypot(Tuple(q)...)
 @inline norm(q::Quaternion) = abs(q)
-@inline inv(q::Quaternion) = conj(q) / abs2(q)
+function inv(q::Quaternion)
+    scale = maximum(abs, Tuple(q))
+    if iszero(scale) || isinf(scale) || isnan(scale)
+        return conj(q) / abs2(q)
+    end
+    p = q / scale
+    conj(p) / (scale * abs2(p))
+end
 
 """
     exp(::Quaternion)
@@ -206,19 +222,53 @@ function Base.exp(q::Quaternion)
 end
 
 """
+    sqrt(::Quaternion)
+
+Return the principal square root of a quaternion.
+
+On the negative real axis, the branch uses the first imaginary basis direction.
+"""
+function Base.sqrt(q::Quaternion)
+    q_norm = norm(q)
+    v = q.vector
+    v_norm = norm(v)
+    if iszero(v_norm)
+        if q.scalar < zero(q.scalar)
+            s = sqrt(-q.scalar)
+            return Quaternion(zero(s), Vec(s, zero(s), zero(s)))
+        end
+        return Quaternion(sqrt(q.scalar), zero(v))
+    end
+    if q.scalar ≥ zero(q.scalar)
+        s = sqrt((q_norm + q.scalar) / 2)
+        return Quaternion(s, v / (2s))
+    end
+    s = v_norm / sqrt(2(q_norm - q.scalar))
+    Quaternion(s, v * sqrt((q_norm - q.scalar) / (2v_norm * v_norm)))
+end
+
+"""
     log(::Quaternion)
 
-Compute the logarithm of quaternion as
+Return the principal logarithm of a quaternion:
 
 ```math
 \\ln(q) = \\ln\\| q \\| + \\frac{\\bm{v}}{\\| \\bm{v} \\|} \\arccos\\frac{q_w}{\\| q \\|}
 ```
+
+On the negative real axis, the branch uses the first imaginary basis direction.
 """
 function Base.log(q::Quaternion)
     q_norm = norm(q)
     v = q.vector
-    ϕ = acos(q.scalar/q_norm)
-    Quaternion(log(q_norm), normalize(v) * ϕ)
+    v_norm = norm(v)
+    iszero(q_norm) && return Quaternion(log(q_norm), zero(v))
+    if iszero(v_norm)
+        ϕ = q.scalar < zero(q.scalar) ? oftype(q_norm, π) : zero(q_norm)
+        return Quaternion(log(q_norm), Vec(ϕ, zero(ϕ), zero(ϕ)))
+    end
+    ϕ = atan(v_norm, q.scalar)
+    Quaternion(log(q_norm), v / v_norm * ϕ)
 end
 
 @inline normalize(q::Quaternion) = q / norm(q)
@@ -259,7 +309,17 @@ julia> rotmat(q)
 """
 @inline rotmat(q::Quaternion) = rotmat_normalized(normalize(q))
 
+function _isnegative_for_show(x)
+    try
+        isnegative = x < zero(x)
+        isnegative isa Bool && return isnegative
+        return false
+    catch
+        return false
+    end
+end
+
 function Base.show(io::IO, q::Quaternion)
-    pm(x) = x < 0 ? " - $(-x)" : " + $x"
+    pm(x) = _isnegative_for_show(x) ? " - $(-x)" : " + $x"
     print(io, q[1], pm(q[2]), "𝙞", pm(q[3]), "𝙟", pm(q[4]), "𝙠")
 end

--- a/test/quaternion.jl
+++ b/test/quaternion.jl
@@ -1,6 +1,3 @@
-ToVec3(x::Vec{3}) = x
-ToVec3(x::Vec{2}) = Vec(x[1], x[2], 0)
-
 @testset "Quaternion" begin
     for T in (Float32, Float64)
         # basic constructors
@@ -8,22 +5,23 @@ ToVec3(x::Vec{2}) = Vec(x[1], x[2], 0)
         @test (@inferred Quaternion{T}(1,2,3,4))::Quaternion{T} |> Tuple === map(T, (1,2,3,4))
         @test (@inferred Quaternion{T}(Vec(1,2,3,4)))::Quaternion{T} |> Tuple === map(T, (1,2,3,4))
         @test (@inferred Quaternion{T}(Vec(1,2,3)))::Quaternion{T} |> Tuple === map(T, (0,1,2,3))
-        @test (@inferred Quaternion{T}(Vec(1,2)))::Quaternion{T} |> Tuple === map(T, (0,1,2,0))
-        @test (@inferred Quaternion{T}(Vec(1)))::Quaternion{T} |> Tuple === map(T, (0,1,0,0))
         @test (@inferred Quaternion{T}(4, Vec(1,2,3)))::Quaternion{T} |> Tuple === map(T, (4,1,2,3))
-        @test (@inferred Quaternion{T}(4, Vec(1,2)))::Quaternion{T} |> Tuple === map(T, (4,1,2,0))
-        @test (@inferred Quaternion{T}(4, Vec(1)))::Quaternion{T} |> Tuple === map(T, (4,1,0,0))
         @test (@inferred Quaternion{T}(4))::Quaternion{T} |> Tuple === map(T, (4,0,0,0))
         @test (@inferred Quaternion((T(1),2,3,4)))::Quaternion{T} |> Tuple === map(T, (1,2,3,4))
         @test (@inferred Quaternion(T(1),2,3,4))::Quaternion{T} |> Tuple === map(T, (1,2,3,4))
         @test (@inferred Quaternion(Vec(T(1),2,3,4)))::Quaternion{T} |> Tuple === map(T, (1,2,3,4))
         @test (@inferred Quaternion(Vec(T(1),2,3)))::Quaternion{T} |> Tuple === map(T, (0,1,2,3))
-        @test (@inferred Quaternion(Vec(T(1),2)))::Quaternion{T} |> Tuple === map(T, (0,1,2,0))
-        @test (@inferred Quaternion(Vec(T(1))))::Quaternion{T} |> Tuple === map(T, (0,1,0,0))
         @test (@inferred Quaternion(T(4), Vec(1,2,3)))::Quaternion{T} |> Tuple === map(T, (4,1,2,3))
-        @test (@inferred Quaternion(T(4), Vec(1,2)))::Quaternion{T} |> Tuple === map(T, (4,1,2,0))
-        @test (@inferred Quaternion(T(4), Vec(1)))::Quaternion{T} |> Tuple === map(T, (4,1,0,0))
         @test (@inferred Quaternion(T(4)))::Quaternion{T} |> Tuple === map(T, (4,0,0,0))
+        @test_throws MethodError Quaternion{T}(Vec(1,2))
+        @test_throws MethodError Quaternion{T}(Vec(1))
+        @test_throws MethodError Quaternion{T}(4, Vec(1,2))
+        @test_throws MethodError Quaternion{T}(4, Vec(1))
+        @test_throws MethodError Quaternion(Vec(T(1),2))
+        @test_throws MethodError Quaternion(Vec(T(1)))
+        @test_throws MethodError Quaternion(T(4), Vec(1,2))
+        @test_throws MethodError Quaternion(T(4), Vec(1))
+        @test_throws ArgumentError Quaternion(1 + 2im)
 
         # properties
         q = Quaternion{T}(1,2,3,4)
@@ -36,10 +34,9 @@ ToVec3(x::Vec{2}) = Vec(x[1], x[2], 0)
         @test (@inferred get_data(q))::NTuple{4, T} == map(T, (1,2,3,4))
 
         # quaternion
-        n2 = normalize(Vec{2, T}(1,2))
         n3 = normalize(Vec{3, T}(1,2,3))
-        @test (@inferred quaternion(T(π/4), n2))::Quaternion{T} == (@inferred quaternion(T(π/4), Vec(n2[1], n2[2], zero(T))))::Quaternion{T}
-        @test (@inferred quaternion(T, π/4, n2))::Quaternion{T} == (@inferred quaternion(T, π/4, Vec(n2[1], n2[2], zero(T))))::Quaternion{T}
+        @test_throws MethodError quaternion(T(π/4), Vec{2, T}(1,2))
+        @test_throws MethodError quaternion(T, π/4, Vec{2, T}(1,2))
         q = (@inferred quaternion(T(π/4), n3))::Quaternion{T}
         q = (@inferred quaternion(T, π/4, n3))::Quaternion{T}
         @test length(q) == 4
@@ -62,6 +59,18 @@ ToVec3(x::Vec{2}) = Vec(x[1], x[2], 0)
         @test ((@inferred promote(q, T(3)))::NTuple{2, Quaternion{T}})[2] == Quaternion(3.0,0,0,0)
         @test ((@inferred promote(q, 3))::NTuple{2, Quaternion{T}})[2] == Quaternion(3.0,0,0,0)
 
+        # number interface
+        @test (@inferred zero(Quaternion{T}))::Quaternion{T} === Quaternion{T}(0,0,0,0)
+        @test (@inferred zero(q))::Quaternion{T} === Quaternion{T}(0,0,0,0)
+        @test (@inferred one(Quaternion{T}))::Quaternion{T} === Quaternion{T}(1,0,0,0)
+        @test (@inferred one(q))::Quaternion{T} === Quaternion{T}(1,0,0,0)
+        @test (@inferred real(Quaternion{T})) === T
+        @test (@inferred iszero(zero(q)))::Bool
+        @test (@inferred isreal(Quaternion{T}(1,0,0,0)))::Bool
+        @test !(@inferred isreal(q))::Bool
+        @test (@inferred isinf(Quaternion{T}(Inf,0,0,0)))::Bool
+        @test (@inferred isnan(Quaternion{T}(NaN,0,0,0)))::Bool
+
         # math operations
         @test (@inferred +q)::Quaternion{T} === q
         @test (@inferred +p)::Quaternion{T} === p
@@ -77,9 +86,17 @@ ToVec3(x::Vec{2}) = Vec(x[1], x[2], 0)
         @test (@inferred p / 2)::Quaternion{T} == Quaternion(Vec(p) / 2)
         @test (@inferred norm(q))::T ≈ (@inferred abs(q))::T
         @test (@inferred norm(p))::T ≈ (@inferred abs(p))::T
+        @test_throws MethodError Quaternion{T}(1, 2, 3)
+        @test_throws MethodError (1 + 2im) * q
+        @test_throws MethodError q * (1 + 2im)
+        @test_throws MethodError q / (1 + 2im)
 
         # angleaxis
         @test (quaternion((@inferred angleaxis(q))::Tuple{T, Vec{3, T}}...)) ≈ q
+        @test quaternion((@inferred angleaxis(-q))::Tuple{T, Vec{3, T}}...) ≈ q
+        @test (@inferred angleaxis(Quaternion{T}(1)))::Tuple{T, Vec{3, T}} === (zero(T), Vec(one(T), zero(T), zero(T)))
+        @test (@inferred angleaxis(Quaternion{T}(-1)))::Tuple{T, Vec{3, T}} === (zero(T), Vec(one(T), zero(T), zero(T)))
+        @test_throws DomainError angleaxis(Quaternion{T}(0))
 
         a = rand(T)
         @test (@inferred exp(log(q)))::Quaternion{T} ≈ q
@@ -89,34 +106,55 @@ ToVec3(x::Vec{2}) = Vec(x[1], x[2], 0)
         @test (@inferred log(a * q))::Quaternion{T} ≈ log(a) + log(q)
         @test (@inferred log(a * p))::Quaternion{T} ≈ log(a) + log(p)
         @test (@inferred exp(Quaternion{T}(1,0,0,0)))::Quaternion{T} ≈ exp(1)
+        @test (@inferred log(Quaternion{T}(2)))::Quaternion{T} ≈ Quaternion{T}(log(T(2)), 0, 0, 0)
+        @test (@inferred log(Quaternion{T}(-2)))::Quaternion{T} ≈ Quaternion{T}(log(T(2)), T(π), 0, 0)
+        logzero = (@inferred log(Quaternion{T}(0)))::Quaternion{T}
+        @test logzero.scalar == T(-Inf)
+        @test logzero.vector === zero(Vec{3, T})
+        @test (@inferred exp(log(Quaternion{T}(-2))))::Quaternion{T} ≈ Quaternion{T}(-2)
+        @test (@inferred sqrt(Quaternion{T}(4)))::Quaternion{T} ≈ Quaternion{T}(2)
+        @test (@inferred sqrt(Quaternion{T}(-4)))::Quaternion{T} ≈ Quaternion{T}(0,2,0,0)
+        @test (@inferred sqrt(q))::Quaternion{T} * sqrt(q) ≈ q
+        @test (@inferred sqrt(p))::Quaternion{T} * sqrt(p) ≈ p
+        qneg = Quaternion{T}(-1, 2, -3, 4)
+        @test (@inferred exp(log(qneg)))::Quaternion{T} ≈ qneg
+        @test (@inferred sqrt(qneg))::Quaternion{T} * sqrt(qneg) ≈ qneg
+
+        qlarge = Quaternion{T}(floatmax(T) / 4, floatmax(T) / 4, floatmax(T) / 4, floatmax(T) / 4)
+        @test (@inferred abs(qlarge))::T ≈ floatmax(T) / 2
+        invlarge = (@inferred inv(Quaternion{T}(floatmax(T) / 4)))::Quaternion{T}
+        @test isfinite(invlarge.scalar)
+        @test invlarge ≈ Quaternion{T}(T(4) / floatmax(T))
+        @test (@inferred inv(qlarge))::Quaternion{T} * qlarge ≈ one(qlarge)
+        @test (@inferred inv(Quaternion{T}(4floatmin(T))))::Quaternion{T} ≈ Quaternion{T}(inv(4floatmin(T)))
 
         Rq = rotmat(q)
         Rp = rotmat(p)
         r = p * q
 
-        for dim in (2, 3)
-            # check multiplications
-            x = rand(Vec{dim, T})
-            x3 = ToVec3(x)
-            @test (q * x / q).vector ≈ Rq * x3
-            @test (p * x / p).vector ≈ Rp * x3
-            @test (r * x / r).vector ≈ Rp * Rq * x3
-            @test (q * x * inv(q)).vector ≈ Rq * x3
-            @test (p * x * inv(p)).vector ≈ Rp * x3
-            @test (r * x * inv(r)).vector ≈ Rp * Rq * x3
-            # inverse of rotation
-            @test (inv(q) * x * q).vector ≈ inv(Rq) * x3
-            # check order of multiplications
-            @test ((q * x) / q).vector ≈ Rq * x3
-            @test (q * (x / q)).vector ≈ Rq * x3
-            # rotate
-            @test rotate(x, q) ≈ rotate(x3, Rq)
-            @test rotate(x, p) ≈ rotate(x3, Rp)
-            @test rotate(x, r) ≈ rotate(x3, Rp * Rq)
-            @test rotate(x, inv(q)) ≈ rotate(x3, inv(Rq))
-            @test rotate(x, inv(p)) ≈ rotate(x3, inv(Rp))
-            @test rotate(x, inv(r)) ≈ rotate(x3, inv(Rp * Rq))
-        end
+        # check multiplications
+        x = rand(Vec{3, T})
+        @test (q * x / q).vector ≈ Rq * x
+        @test (p * x / p).vector ≈ Rp * x
+        @test (r * x / r).vector ≈ Rp * Rq * x
+        @test (q * x * inv(q)).vector ≈ Rq * x
+        @test (p * x * inv(p)).vector ≈ Rp * x
+        @test (r * x * inv(r)).vector ≈ Rp * Rq * x
+        # inverse of rotation
+        @test (inv(q) * x * q).vector ≈ inv(Rq) * x
+        # check order of multiplications
+        @test ((q * x) / q).vector ≈ Rq * x
+        @test (q * (x / q)).vector ≈ Rq * x
+        # rotate
+        @test rotate(x, q) ≈ rotate(x, Rq)
+        @test rotate(x, p) ≈ rotate(x, Rp)
+        @test rotate(x, r) ≈ rotate(x, Rp * Rq)
+        @test rotate(x, inv(q)) ≈ rotate(x, inv(Rq))
+        @test rotate(x, inv(p)) ≈ rotate(x, inv(Rp))
+        @test rotate(x, inv(r)) ≈ rotate(x, inv(Rp * Rq))
+        @test_throws MethodError rotate(rand(Vec{2, T}), q)
+        @test_throws MethodError q * rand(Vec{2, T})
+        @test_throws MethodError rand(Vec{2, T}) / q
         # test with rotmat(θ, n)
         θ = rand(T)
         n = normalize(rand(Vec{3, T}))


### PR DESCRIPTION
Refine quaternion construction and operations. This removes implicit 1D/2D vector quaternion paths, defines the missing Number interface, adds principal sqrt/log behavior for real-axis edge cases, and makes abs/inv more robust for extreme floating-point values.