### PR TITLE
Fix high-order AD inference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Tensorial"
 uuid = "98f94333-fa9f-48a9-ad80-1c66397b2b38"
-version = "0.20.4"
+version = "0.20.5"
 authors = ["Keita Nakamura <keita.nakamura.1109@gmail.com>"]
 
 [deps]

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -33,7 +33,7 @@ end
 @inline dualize(f, x) = _dualize(Tag(f, typeof(x)), x)
 @inline dualize(f, x, ::Val{0}) = x
 @inline dualize(f, x, ::Val{1}) = dualize(f, x)
-@inline dualize(f, x, ::Val{N}) where {N} = dualize(f, dualize(f, x), Val(N-1))
+@inline dualize(f, x, ::Val{N}) where {N} = dualize(f, dualize(f, x, Val(N-1)))
 
 # single argument
 @inline function _dualize(::Tg, x::Number) where {Tg}

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -120,6 +120,13 @@
         @test all((@inferred ∂{4}(norm, x, :all)) .≈ (∂⁴f, ∂³f, ∂²f, ∂f, f))
         @test all((@inferred ∂{0}(norm, x, :all)) .≈ (f,))
 
+        y = rand(T)
+        @test all((@inferred ∂{5}(sin, y, :all)) .≈
+                  (cos(y), sin(y), -cos(y), -sin(y), cos(y), sin(y)))
+
+        mixed = @inferred ∂{5}((a, b) -> (a + b)^5, T(1), T(2), :all)
+        @test last(mixed) == T(3)^5
+
         H = @inferred ∂{2}(x -> x ⋅ x, x)
         @test H isa SymmetricSecondOrderTensor{2,T}
         @test Tuple(Tensorial.Space(H)) == (Symmetry(2,2),)


### PR DESCRIPTION
Reorders nested dual construction so Julia retains concrete `ForwardDiff.Dual` types for fifth- and higher-order derivatives without changing the computed values.

Adds scalar and multiple-input inference regressions and bumps the package version to v0.20.5.